### PR TITLE
All promises

### DIFF
--- a/js-exercises/all-promises/README.md
+++ b/js-exercises/all-promises/README.md
@@ -1,0 +1,24 @@
+# Instructions
+
+Implement a function `allPromises`. It has the same API(input, output, behaviour) as that of `Promise.all`.
+
+## Examples
+
+```js
+const promise1 = Promise.resolve(3);
+const promise2 = 42;
+const promise3 = new Promise((resolve, reject) => {
+  setTimeout(resolve, 100, 'foo');
+});
+
+allPromises([promise1, promise2, promise3]).then((values) => {
+  console.log(values);
+});
+// expected output: Array [3, 42, "foo"]
+```
+
+# Restrictions
+
+- If passed an array, should return an array of values from the promises
+- DO NOT USE `Promise.all`
+- You can use built-in `Promise` constructor.

--- a/js-exercises/all-promises/allPromises.js
+++ b/js-exercises/all-promises/allPromises.js
@@ -1,0 +1,18 @@
+const allPromises = (promises) => new Promise((resolve, reject) => {
+  let counter = promises.length - 1;
+  const results = [];
+  const resolver = (result, index) => {
+    counter -= 1;
+    results[index] = result;
+    if (counter === 0) {
+      resolve(results);
+    }
+  };
+  promises.forEach((promise, index) => {
+    Promise.resolve(promise)
+      .then((result) => resolver(result, index))
+      .catch((error) => reject(error));
+  });
+});
+
+export { allPromises };

--- a/js-exercises/all-promises/allPromises.test.js
+++ b/js-exercises/all-promises/allPromises.test.js
@@ -1,0 +1,14 @@
+import { allPromises } from './allPromises';
+
+describe('allPromises', () => {
+  test('The function should return a Promise', () => {
+    expect(allPromises() instanceof Promise).toBe(true);
+  });
+
+  test('Promise call should return an array of values from promises', () => {
+    const p1 = new Promise(res => res(1));
+    const p2 = 2;
+    const p3 = Promise.resolve(3);
+    return expect(allPromises([p1, p2, p3])).resolves.toEqual([1, 2, 3]);
+  });
+});


### PR DESCRIPTION
# Instructions

Implement a function `allPromises`. It has the same API(input, output, behaviour) as that of `Promise.all`.

## Examples

```js
const promise1 = Promise.resolve(3);
const promise2 = 42;
const promise3 = new Promise((resolve, reject) => {
  setTimeout(resolve, 100, 'foo');
});

allPromises([promise1, promise2, promise3]).then((values) => {
  console.log(values);
});
// expected output: Array [3, 42, "foo"]
```

# Restrictions

- If passed an array, should return an array of values from the promises
- DO NOT USE `Promise.all`
- You can use built-in `Promise` constructor.
