### PR TITLE
Apperture

### DIFF
--- a/js-exercises/aperture/README.md
+++ b/js-exercises/aperture/README.md
@@ -1,0 +1,12 @@
+## Instructions
+
+Returns a new list, composed of n-tuples of consecutive elements. If `n` is
+greater than the length of the list, an empty list is returned.
+
+Acts as a transducer if a transformer is given in list position.
+
+```js
+aperture(2, [1, 2, 3, 4, 5]); //=> [[1, 2], [2, 3], [3, 4], [4, 5]]
+aperture(3, [1, 2, 3, 4, 5]); //=> [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+aperture(7, [1, 2, 3, 4, 5]); //=> []
+```

--- a/js-exercises/aperture/aperture.js
+++ b/js-exercises/aperture/aperture.js
@@ -1,0 +1,36 @@
+function NTuples(n) {
+  this.tupleLength = n;
+  this.tuples = [[]];
+  this.currentIndex = 0;
+}
+
+NTuples.prototype.push = function (item) {
+  if (this.tuples[this.currentIndex].length < this.tupleLength) {
+    return this.tuples[this.currentIndex].push(item);
+  }
+
+  this.currentIndex += 1;
+  this.tuples[this.currentIndex] = [item];
+  return 1;
+};
+
+NTuples.prototype.valueOf = function () {
+  return this.tuples;
+};
+
+function aperture(n, list) {
+  const tuples = new NTuples(n);
+  if (n > list.length) {
+    return [];
+  }
+
+  for (let outer = 0; outer <= list.length - n; outer += 1) {
+    for (let inner = outer; inner < outer + n; inner += 1) {
+      tuples.push(list[inner]);
+    }
+  }
+
+  return tuples.valueOf();
+}
+
+export { aperture };

--- a/js-exercises/aperture/aperture.test.js
+++ b/js-exercises/aperture/aperture.test.js
@@ -1,0 +1,29 @@
+import { aperture } from "./aperture";
+
+describe("aperture", () => {
+  const sevenLs = [1, 2, 3, 4, 5, 6, 7];
+  it("creates a list of n-tuples from a list", () => {
+    expect(aperture(1, sevenLs)).toEqual([[1], [2], [3], [4], [5], [6], [7]]);
+    expect(aperture(2, sevenLs)).toEqual([
+      [1, 2],
+      [2, 3],
+      [3, 4],
+      [4, 5],
+      [5, 6],
+      [6, 7],
+    ]);
+    expect(aperture(3, sevenLs)).toEqual([
+      [1, 2, 3],
+      [2, 3, 4],
+      [3, 4, 5],
+      [4, 5, 6],
+      [5, 6, 7],
+    ]);
+    expect(aperture(4, [1, 2, 3, 4])).toEqual([[1, 2, 3, 4]]);
+  });
+
+  it("returns an empty list when `n` > `list.length`", () => {
+    expect(aperture(6, [1, 2, 3])).toEqual([]);
+    expect(aperture(1, [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Instructions

Returns a new list, composed of n-tuples of consecutive elements. If `n` is
greater than the length of the list, an empty list is returned.

Acts as a transducer if a transformer is given in list position.

```js
aperture(2, [1, 2, 3, 4, 5]); //=> [[1, 2], [2, 3], [3, 4], [4, 5]]
aperture(3, [1, 2, 3, 4, 5]); //=> [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
aperture(7, [1, 2, 3, 4, 5]); //=> []
```
